### PR TITLE
Explicitly fail when the hiscores API changes

### DIFF
--- a/src/hiscores.js
+++ b/src/hiscores.js
@@ -167,6 +167,8 @@ const _parseBosses = (statsArray) => {
 const _parseStats = (stats) => {
   if (!stats || !Array.isArray(stats) || stats.length <= 0)
     throw new Error('Invalid stats array received!');
+  if (stats.length !== 84)
+    throw new Error('This version of osrs-json-api is no longer compatible with the hiscores API');
 
   const player = {};
 


### PR DESCRIPTION
Fixes #34 

When new rows are added to the hiscores CSV API, old versions of `osrs-json-api` can return corrupted data due to incorrect mappings from rows to skill/boss/etc. To avoid returning corrupted data to applications using old versions of `osrs-json-api`, we will treat this as an explicit failure with an actionable error message.

Something we may want to consider: contributors may forget to bump this number for future updates. Perhaps we can dynamically parse the stats array using some source data (e.g. list of skills, bosses, etc.) rather than having contributors manually set the indexes we want to slice. The good news is that if contributors forget to bump the number used for validation, it will simply fail rather than return corrupted data.